### PR TITLE
add role for wordpress and mariadb setup on ALP-Dolomite

### DIFF
--- a/wordpress_mariadb/README.md
+++ b/wordpress_mariadb/README.md
@@ -1,37 +1,31 @@
-Ansible Role: wordpress_mariadb
-Description
+# Ansible Role: wordpress_mariadb
 
-This Ansible role is designed to simplify the installation and configuration of containerised MariaDB, and WordPress on ALP-Dolomite using podman. It streamlines the setup process, ensuring that you have a sample WordPress site up and running quickly.
+## Description
 
-Role Variables
+This Ansible role is designed to simplify the installation and configuration of containerized MariaDB and WordPress on ALP-Dolomite using podman. It streamlines the setup process, ensuring that you have a sample WordPress site up and running quickly.
 
-The following variables can be customized as per your requirements:
+## Role Variables
 
-    db_name 
-        Inform the name of the WordPress database.
+You can customize the following variables as per your requirements:
 
-    db_user 
-        Inform the username for the WordPress database.
+| Variable Name        | Default Value                 | Description                                           |
+|----------------------|-------------------------------|-------------------------------------------------------|
+| `app_name`           | `wordpress-test-app`         | The name of the WordPress application.                |
+| `wordpress_volume`   | `wordpress`                   | The volume for WordPress data.                        |
+| `image.wordpress`    | `docker.io/library/wordpress` | The WordPress container image.                        |
+| `image.mariadb`      | `registry.opensuse.org/opensuse/mariadb` | The MariaDB container image.          |
+| `database.user`      | `wordpress_user`             | The username for the WordPress database.             |
+| `database.database`  | `db`                          | The name of the WordPress database.                   |
+| `database.password`  | `database_password`           | The password for the WordPress database.              |
+| `database.root_password` | `database_root_password`   | The root password for MariaDB.                       |
+| `database.host`      | `mariadb`                     | The host where the database is located.              |
+| `database.volume`    | `mariadb`                     | The volume for MariaDB data.                         |
 
-    root_login 
-        Specify the root user for MariaDB.
-
-    root_password 
-        Set the root password for MariaDB.
-
-    db_host 
-        Specify the database host.
-
-Example Playbook
+## Example Playbook
 
 Here is an example playbook demonstrating how to use this role:
 
-yaml
-
+```yaml
 - hosts: alphost
   roles:
-    - role: /path/mariadb_apache_wordpress
-
-Contributing
-
-We welcome contributions, bug reports, feature requests, and ideas. Please feel free to create issues in the Issues section of this repository.
+    - wordpress_mariadb

--- a/wordpress_mariadb/README.md
+++ b/wordpress_mariadb/README.md
@@ -1,0 +1,37 @@
+Ansible Role: wordpress_mariadb
+Description
+
+This Ansible role is designed to simplify the installation and configuration of containerised MariaDB, and WordPress on ALP-Dolomite using podman. It streamlines the setup process, ensuring that you have a sample WordPress site up and running quickly.
+
+Role Variables
+
+The following variables can be customized as per your requirements:
+
+    db_name 
+        Inform the name of the WordPress database.
+
+    db_user 
+        Inform the username for the WordPress database.
+
+    root_login 
+        Specify the root user for MariaDB.
+
+    root_password 
+        Set the root password for MariaDB.
+
+    db_host 
+        Specify the database host.
+
+Example Playbook
+
+Here is an example playbook demonstrating how to use this role:
+
+yaml
+
+- hosts: alphost
+  roles:
+    - role: /path/mariadb_apache_wordpress
+
+Contributing
+
+We welcome contributions, bug reports, feature requests, and ideas. Please feel free to create issues in the Issues section of this repository.

--- a/wordpress_mariadb/defaults/main.yml
+++ b/wordpress_mariadb/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+app_name: wordpress-test-app
+wordpress_volume: wordpress
+
+image:
+  wordpress: docker.io/library/wordpress
+  mariadb: registry.opensuse.org/opensuse/mariadb
+
+database:
+  user: wordpress_user
+  database: db
+  password: database_password
+  root_password: database_root_password
+  host: mariadb
+  volume: mariadb

--- a/wordpress_mariadb/meta/main.yml
+++ b/wordpress_mariadb/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: wordpress_mariadb
+  author: harshvardhan.sharma
+  description: Setup wordpress and mariadb using podman.
+  company: SUSE
+  license: Apache
+  min_ansible_version: "6.0"
+  platforms:
+    - name: opensuse
+      versions:
+        - "15.4"
+  galaxy_tags:
+    - alp
+    - dolomite
+    - SUSE

--- a/wordpress_mariadb/tasks/install_mariadb.yml
+++ b/wordpress_mariadb/tasks/install_mariadb.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Retrieve mariadb image {{ image.mariadb }}
+  containers.podman.podman_image:
+    name: "{{ image.mariadb }}"
+    state: present
+
+- name: Create MariaDB data volume
+  containers.podman.podman_volume:
+    name: "{{ database.volume }}"
+
+- name: Create a app pod
+  containers.podman.podman_pod:
+    name: "{{ app_name }}"
+    infra: true
+    publish:
+      - "8080:80"
+    network: bridge
+
+- name: Run MariaDB container
+  containers.podman.podman_container:
+    name: "{{ database.host }}"
+    image: registry.opensuse.org/opensuse/mariadb
+    pod: "{{ app_name }}"
+    restart_policy: always
+    env:
+      MYSQL_USER: "{{ database.user }}"
+      MYSQL_PASSWORD: "{{ database.password }}"
+      MYSQL_DATABASE: "{{ database.database }}"
+      MYSQL_ROOT_PASSWORD: "{{ database.root_password }}"
+    volume:
+      - "{{ database.volume }}:/var/lib/mysql:Z"
+    state: started

--- a/wordpress_mariadb/tasks/install_wordpress.yml
+++ b/wordpress_mariadb/tasks/install_wordpress.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Retrieve wordpress image
+  containers.podman.podman_image:
+    name: "{{ image.wordpress }}"
+    state: present
+
+- name: Create wordpress data volume
+  containers.podman.podman_volume:
+    name: "{{ wordpress_volume }}"
+
+- name: Run wordpress container
+  containers.podman.podman_container:
+    name: wordpress
+    image: "{{ image.wordpress }}"
+    pod: "{{ app_name }}"
+    restart_policy: always
+    volume:
+      - "{{ wordpress_volume }}:/var/www/html"
+    env:
+      WORDPRESS_DB_USER: "{{ database.user }}"
+      WORDPRESS_DB_NAME: "{{ database.database }}"
+      WORDPRESS_DB_PASSWORD: "{{ database.password }}"
+      WORDPRESS_DB_HOST: "{{ database.host }}"
+    state: started

--- a/wordpress_mariadb/tasks/main.yml
+++ b/wordpress_mariadb/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Setup mariadb
+  ansible.builtin.include_tasks: install_mariadb.yml
+
+- name: Setup wordpress
+  ansible.builtin.include_tasks: install_wordpress.yml


### PR DESCRIPTION
add role for wordpress and mariadb setup on ALP-Dolomite